### PR TITLE
Stalled Scenario: isolated API reconnection

### DIFF
--- a/packages/server/src/services/networking/bitcoin/client.ts
+++ b/packages/server/src/services/networking/bitcoin/client.ts
@@ -148,12 +148,17 @@ export class BitcoinApi implements ApiClient {
     return await this.#call<ChainInfo>('getblockchaininfo')
   }
 
-  connect() {
+  async connect() {
     return Promise.resolve(this)
   }
 
-  disconnect() {
+  async disconnect() {
     this.#controller.abort('disconnected')
+  }
+
+  async reconnect() {
+    await this.disconnect()
+    return this.connect()
   }
 
   async #call<T>(method: string, params: (string | number)[] = []): Promise<T> {

--- a/packages/server/src/services/networking/bitcoin/client.ts
+++ b/packages/server/src/services/networking/bitcoin/client.ts
@@ -156,11 +156,6 @@ export class BitcoinApi implements ApiClient {
     this.#controller.abort('disconnected')
   }
 
-  async reconnect() {
-    await this.disconnect()
-    return this.connect()
-  }
-
   async #call<T>(method: string, params: (string | number)[] = []): Promise<T> {
     const body = {
       jsonrpc: '1.0',

--- a/packages/server/src/services/networking/bitcoin/ingress/watcher.spec.ts
+++ b/packages/server/src/services/networking/bitcoin/ingress/watcher.spec.ts
@@ -15,7 +15,7 @@ async function simulateReorg(tracked: NeutralHeader[], replaced: NeutralHeader[]
   })
   const mockServices = createServices()
   mockServices.connector = {
-    connect: () => ({
+    connectAll: () => ({
       'urn:ocn:bitcoin:0': {
         followHeads$: () => from(tracked),
         getBlock: (hash: string) => {

--- a/packages/server/src/services/networking/bitcoin/ingress/watcher.ts
+++ b/packages/server/src/services/networking/bitcoin/ingress/watcher.ts
@@ -21,7 +21,7 @@ export class BitcoinWatcher extends Watcher<Block> {
 
     const { connector } = services
 
-    this.#apis = connector.connect('bitcoin')
+    this.#apis = connector.connectAll('bitcoin')
     this.chainIds = (Object.keys(this.#apis) as NetworkURN[]) ?? []
   }
 

--- a/packages/server/src/services/networking/connector.spec.ts
+++ b/packages/server/src/services/networking/connector.spec.ts
@@ -11,7 +11,7 @@ describe('connector', () => {
   describe('connect', () => {
     it('should return all network apis with RPC-only config', () => {
       const connector = new Connector(_log, mockConfigWS)
-      const apis = connector.connect('substrate')
+      const apis = connector.connectAll('substrate')
 
       expect(Object.keys(apis).length).toBe(3)
       expect(apis['urn:ocn:local:0']).toBeDefined()
@@ -21,7 +21,7 @@ describe('connector', () => {
 
     it('should return all network apis with relay network as the last item in the config', () => {
       const connector = new Connector(_log, mockConfigRelayLast)
-      const apis = connector.connect('substrate')
+      const apis = connector.connectAll('substrate')
 
       expect(Object.keys(apis).length).toBe(3)
       expect(apis['urn:ocn:local:0']).toBeDefined()
@@ -31,11 +31,11 @@ describe('connector', () => {
 
     it('should return apis if already registered', () => {
       const connector = new Connector(_log, mockConfigWS)
-      const apis = connector.connect('substrate')
+      const apis = connector.connectAll('substrate')
 
       expect(Object.keys(apis).length).toBe(3)
 
-      const apisToo = connector.connect('substrate')
+      const apisToo = connector.connectAll('substrate')
       expect(apisToo).toEqual(apis)
     })
   })
@@ -43,12 +43,12 @@ describe('connector', () => {
   describe('disconnect', () => {
     it('should call disconnect on apis', () => {
       const connector = new Connector(_log, mockConfigWS)
-      const apis = connector.connect('substrate')
+      const apis = connector.connectAll('substrate')
 
       expect(Object.keys(apis).length).toBe(3)
 
       const disconnectSpy = vi.spyOn(Object.values(apis)[0], 'disconnect')
-      connector.disconnect()
+      connector.disconnectAll()
       expect(disconnectSpy).toHaveBeenCalled()
     })
   })

--- a/packages/server/src/services/networking/connector.ts
+++ b/packages/server/src/services/networking/connector.ts
@@ -47,7 +47,7 @@ export default class Connector {
     }
   }
 
-  connect<T extends ApiClient>(clientId: ClientId): Record<string, T> {
+  connectAll<T extends ApiClient>(clientId: ClientId): Record<string, T> {
     const chains = this.#chains.get(clientId) ?? {}
 
     this.#log.info('[connector] %s connect clients: %j', clientId, Object.keys(chains))
@@ -72,10 +72,10 @@ export default class Connector {
     return chains as Record<string, T>
   }
 
-  async disconnect() {
+  async disconnectAll() {
     const clients = new Array(...this.#chains.values()).flatMap((v) => Object.values(v))
     for (const client of clients) {
-      client.disconnect()
+      await client.disconnect()
     }
 
     this.#log.info('Closing connections: OK')

--- a/packages/server/src/services/networking/plugin.ts
+++ b/packages/server/src/services/networking/plugin.ts
@@ -21,7 +21,7 @@ const connectorPlugin: FastifyPluginAsync = async (fastify) => {
   fastify.addHook('onClose', (_, done) => {
     fastify.log.info('[connector] stopping')
 
-    connector.disconnect().finally(done)
+    connector.disconnectAll().finally(done)
   })
 }
 

--- a/packages/server/src/services/networking/substrate/client.ts
+++ b/packages/server/src/services/networking/substrate/client.ts
@@ -197,7 +197,7 @@ export class SubstrateClient extends EventEmitter implements SubstrateApi {
     }
   }
 
-  connect() {
+  async connect() {
     this.#runtimeManager
       .init()
       .then(() => {
@@ -210,7 +210,7 @@ export class SubstrateClient extends EventEmitter implements SubstrateApi {
     return this.isReady()
   }
 
-  disconnect() {
+  async disconnect() {
     try {
       this.#head.unfollow()
     } catch {
@@ -218,6 +218,11 @@ export class SubstrateClient extends EventEmitter implements SubstrateApi {
     } finally {
       this.#client.destroy()
     }
+  }
+
+  async reconnect() {
+    await this.disconnect()
+    return this.connect()
   }
 
   async getRpcMethods() {

--- a/packages/server/src/services/networking/substrate/client.ts
+++ b/packages/server/src/services/networking/substrate/client.ts
@@ -53,6 +53,10 @@ export class SubstrateClient extends EventEmitter implements SubstrateApi {
 
   #runtimeManager: RuntimeManager
 
+  get rpc() {
+    return this.#rpc
+  }
+
   get #finalized$(): Observable<BlockInfoWithStatus> {
     return this.#head.finalized$.pipe(map((b) => ({ ...b, status: 'finalized' })))
   }

--- a/packages/server/src/services/networking/substrate/client.ts
+++ b/packages/server/src/services/networking/substrate/client.ts
@@ -220,11 +220,6 @@ export class SubstrateClient extends EventEmitter implements SubstrateApi {
     }
   }
 
-  async reconnect() {
-    await this.disconnect()
-    return this.connect()
-  }
-
   async getRpcMethods() {
     return this.#rpc.getRpcMethods()
   }

--- a/packages/server/src/services/networking/substrate/ingress/consumer/distributed.ts
+++ b/packages/server/src/services/networking/substrate/ingress/consumer/distributed.ts
@@ -21,7 +21,7 @@ import { HexString } from '@/services/subscriptions/types.js'
 import { TelemetryCollect, TelemetryEventEmitter } from '@/services/telemetry/types.js'
 import { safeDestr } from 'destr'
 import { decodeBlock } from '../../codec.js'
-import { Block, SubstrateApiContext, createRuntimeApiContext } from '../../index.js'
+import { Block, SubstrateApiContext, createContextFromOpaqueMetadata } from '../../index.js'
 import { SubstrateIngressConsumer, SubstrateNetworkInfo } from '../types.js'
 
 /**
@@ -112,7 +112,7 @@ export class SubstrateDistributedConsumer
 
             throw new Error(`No metadata found for ${chainId}`)
           }
-          return createRuntimeApiContext(metadata, chainId)
+          return createContextFromOpaqueMetadata(metadata, chainId)
         }),
         // TODO retry
         shareReplay({

--- a/packages/server/src/services/networking/substrate/runtime.ts
+++ b/packages/server/src/services/networking/substrate/runtime.ts
@@ -100,7 +100,7 @@ export function createRuntimeManager({
     const metadata = await Promise.race([
       rpc.getMetadata(),
       new Promise<never>((_, reject) =>
-        setTimeout(() => reject(new Error('Runtime call get metadata failed')), 5000),
+        setTimeout(() => reject(new Error('Runtime call get metadata failed')), 20_000),
       ),
     ])
     return createContextFromOpaqueMetadata(fromHex(metadata), chainId)

--- a/packages/server/src/services/networking/substrate/runtime.ts
+++ b/packages/server/src/services/networking/substrate/runtime.ts
@@ -96,10 +96,15 @@ export function createRuntimeManager({
   )
 
   async function fallbackRuntime(): Promise<RuntimeApiContext> {
-    log.warn('[%s] Fallback to state_getMetadata', chainId)
+    // NOTE: whilst is lighter to get the metadata suing state get_Metadata,
+    // Acala in particular, returns an outdated version.
+    // So, for safety we fetch it from the runtime itself.
+    log.warn('[%s] Fallback to runtime call Metadata_metadata', chainId)
     const metadata = await Promise.race([
-      rpc.getMetadata(),
-      new Promise<never>((_, reject) => setTimeout(() => reject(new Error('getMetadata timeout')), 5000)),
+      rpc.runtimeCall('Metadata_metadata'),
+      new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error('Runtime call Metadata_metadata failed')), 5000),
+      ),
     ])
     return createRuntimeApiContext(fromHex(metadata), chainId)
   }

--- a/packages/server/src/services/networking/substrate/watcher/watcher.spec.ts
+++ b/packages/server/src/services/networking/substrate/watcher/watcher.spec.ts
@@ -12,6 +12,39 @@ import { ApiOps } from '../../types.js'
 import { BlockInfo, SubstrateApi } from '../types.js'
 import { SubstrateWatcher } from './watcher.js'
 
+function waitForEmissions<T>(obs: Observable<T>, expectedCount: number, stopFn?: () => void): Promise<void> {
+  return new Promise((resolve, reject) => {
+    let receivedCount = 0
+
+    const subscription = obs.subscribe({
+      next: () => {
+        receivedCount++
+        if (receivedCount === expectedCount) {
+          subscription.unsubscribe()
+          if (stopFn) {
+            stopFn()
+          }
+          resolve()
+        }
+      },
+      error: (err) => {
+        if (stopFn) {
+          stopFn()
+        }
+        reject(err)
+      },
+      complete: () => {
+        if (receivedCount !== expectedCount) {
+          if (stopFn) {
+            stopFn()
+          }
+          reject(new Error(`Stream completed early: got ${receivedCount}, expected ${expectedCount}`))
+        }
+      },
+    })
+  })
+}
+
 function createConnector(headersSource: Observable<BlockInfo>, testHeaders: BlockInfo[]) {
   const mockApi = {
     followHeads$: (finality = 'finalized') =>
@@ -39,7 +72,7 @@ function createConnector(headersSource: Observable<BlockInfo>, testHeaders: Bloc
     },
   } as ApiOps
   return {
-    connect: () => ({
+    connectAll: () => ({
       'urn:ocn:local:0': {
         isReady: () => {
           return Promise.resolve(mockApi)
@@ -82,65 +115,37 @@ describe('head catcher', () => {
         levelDB: db,
       })
 
-      await new Promise<void>((resolve) => {
-        const cb = [vi.fn(), vi.fn()]
-        catcher.start()
-
-        let completes = 0
-        catcher.finalizedBlocks('urn:ocn:local:0').subscribe({
-          next: (_x) => {
-            cb[0]()
-          },
-          complete: async () => {
-            expect(cb[0]).toHaveBeenCalledTimes(9)
-
-            completes++
-            if (completes === 2) {
-              catcher.stop()
-              resolve()
-            }
-          },
-        })
-
-        catcher.finalizedBlocks('urn:ocn:local:0').subscribe({
-          next: () => {
-            cb[1]()
-          },
-          complete: async () => {
-            expect(cb[1]).toHaveBeenCalledTimes(9)
-
-            completes++
-            if (completes === 2) {
-              catcher.stop()
-              resolve()
-            }
-          },
-        })
-      })
+      await Promise.all([
+        waitForEmissions(catcher.finalizedBlocks('urn:ocn:local:0'), 9, () => catcher.stop()),
+        waitForEmissions(catcher.finalizedBlocks('urn:ocn:local:0'), 9, () => catcher.stop()),
+      ])
     })
   })
 
   it('should recover block ranges', async () => {
     // Pretend that we left off at block #23075466
-    db.sublevel<string, ChainHead>(prefixes.cache.tips, jsonEncoded).put('urn:ocn:local:0', {
+    await db.sublevel<string, ChainHead>(prefixes.cache.tips, jsonEncoded).put('urn:ocn:local:0', {
       chainId: 'urn:ocn:local:0',
       blockNumber: '23075466',
     } as unknown as ChainHead)
+
     // Pretend that we got interrupted
     const range: BlockNumberRange = {
       fromBlockNum: 23075465,
       toBlockNum: 23075458,
     }
-    db.sublevel<string, BlockNumberRange>(prefixes.cache.ranges('urn:ocn:local:0'), jsonEncoded).put(
-      prefixes.cache.keys.range(range),
-      range,
-    )
+    await db
+      .sublevel<string, BlockNumberRange>(prefixes.cache.ranges('urn:ocn:local:0'), jsonEncoded)
+      .put(prefixes.cache.keys.range(range), range)
+
     const testHeaders = polkadotBlocks.map(
       ({ hash, number, parent }) => ({ hash, number, parent }) as BlockInfo,
     )
+
     // We will emit the last finalized headers
     const headersSource = from([testHeaders[7], testHeaders[8]])
     const blocksSource = from(polkadotBlocks)
+
     const catcher = new SubstrateWatcher({
       ...services,
       localConfig: mockConfigWS,
@@ -148,22 +153,25 @@ describe('head catcher', () => {
       levelDB: db,
     })
 
-    await new Promise<void>((resolve) => {
-      const cb = vi.fn()
-      catcher.start()
+    catcher.start()
 
+    // Wait for the blocksSource to complete first,
+    // then wait for finalizedBlocks emissions
+    await new Promise<void>((resolve, reject) => {
       blocksSource.subscribe({
         complete: async () => {
-          catcher.finalizedBlocks('urn:ocn:local:0').subscribe({
-            next: (_) => {
-              cb()
-            },
-            complete: async () => {
-              catcher.stop()
-              expect(cb).toHaveBeenCalledTimes(testHeaders.length)
-              resolve()
-            },
-          })
+          try {
+            await waitForEmissions(catcher.finalizedBlocks('urn:ocn:local:0'), testHeaders.length, () =>
+              catcher.stop(),
+            )
+            resolve()
+          } catch (err) {
+            catcher.stop()
+            reject(err)
+          }
+        },
+        error: (err) => {
+          reject(err)
         },
       })
     })
@@ -176,7 +184,7 @@ describe('head catcher', () => {
         ...services,
         localConfig: mockConfigWS,
         connector: {
-          connect: () => ({
+          connectAll: () => ({
             'urn:ocn:local:0': {} as unknown as SubstrateApi,
             'urn:ocn:local:1000': {
               getStorage: mockUpwardMessagesQuery,
@@ -205,7 +213,7 @@ describe('head catcher', () => {
         ...services,
         localConfig: mockConfigWS,
         connector: {
-          connect: () => ({
+          connectAll: () => ({
             'urn:ocn:local:0': {} as unknown as SubstrateApi,
             'urn:ocn:local:1000': {
               getStorage: mockHrmpOutboundMessagesQuery,

--- a/packages/server/src/services/networking/substrate/watcher/watcher.ts
+++ b/packages/server/src/services/networking/substrate/watcher/watcher.ts
@@ -28,7 +28,7 @@ import { Block, SubstrateApi } from '../types.js'
 import { SubstrateBackfill } from './backfill.js'
 import { fetchers } from './fetchers.js'
 
-const API_TIMEOUT_MS = 20_000 // 5 * 60_000
+const API_TIMEOUT_MS = 5 * 60_000
 
 /**
  * The SubstrateWatcher performs the following tasks ("moo" 🐮):

--- a/packages/server/src/services/networking/types.ts
+++ b/packages/server/src/services/networking/types.ts
@@ -20,5 +20,6 @@ export interface ApiClient extends ApiOps {
   readonly chainId: string
 
   connect(): Promise<ApiClient>
-  disconnect(): void
+  disconnect(): Promise<void>
+  reconnect(): Promise<ApiClient>
 }

--- a/packages/server/src/services/networking/types.ts
+++ b/packages/server/src/services/networking/types.ts
@@ -21,5 +21,4 @@ export interface ApiClient extends ApiOps {
 
   connect(): Promise<ApiClient>
   disconnect(): Promise<void>
-  reconnect(): Promise<ApiClient>
 }

--- a/packages/server/src/testing/blocks.ts
+++ b/packages/server/src/testing/blocks.ts
@@ -5,14 +5,14 @@ import { fileURLToPath } from 'node:url'
 import { Abi } from 'viem'
 
 import { decodeBlock } from '@/services/networking/substrate/codec.js'
-import { Block, createRuntimeApiContext } from '@/services/networking/substrate/index.js'
+import { Block, createContextFromMetadata } from '@/services/networking/substrate/index.js'
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url))
 const blocksDir = resolve(__dirname, '__data__/blocks')
 
 export function testApiContextFromMetadata(metadataFile: string) {
   const m = readFileSync(resolve(__dirname, '__data__/metadata', metadataFile))
-  return createRuntimeApiContext(m)
+  return createContextFromMetadata(m)
 }
 
 export function testBlocksFrom(file: string) {

--- a/packages/server/src/testing/services.ts
+++ b/packages/server/src/testing/services.ts
@@ -34,7 +34,7 @@ function mockApiClient() {
   }
   return {
     ..._client,
-    isReady: () => of(_client),
+    isReady: () => Promise.resolve(_client),
     connect: () => Promise.resolve(_client),
   } as unknown as SubstrateApi
 }
@@ -51,7 +51,8 @@ export const _mockApis = {
 }
 
 export const _connector = {
-  connect: () => _mockApis,
+  connectAll: () => _mockApis,
+  disconnectAll: () => Promise.resolve(),
 } as unknown as Connector
 
 export function createServices(): Services {

--- a/packages/server/src/testing/tools/runtime_meta.ts
+++ b/packages/server/src/testing/tools/runtime_meta.ts
@@ -1,0 +1,12 @@
+import { SubstrateClient } from '@/services/networking/substrate/client.js'
+import { createContextFromOpaqueMetadata } from '@/services/networking/substrate/context.js'
+import { pino } from 'pino'
+import { fromHex } from 'polkadot-api/utils'
+
+const client = new SubstrateClient(pino(), 'chain', 'wss://api.interlay.io/parachain')
+
+//const m = await client.rpc.runtimeCall('Metadata_metadata_at_version', toHex(u32.enc(15)))
+const m = await client.rpc.getMetadata()
+console.log('start', m.substring(0, 50))
+const ctx = createContextFromOpaqueMetadata(fromHex(m), 'lol')
+console.log(ctx)

--- a/packages/server/src/testing/tools/stall-proxy.ts
+++ b/packages/server/src/testing/tools/stall-proxy.ts
@@ -1,0 +1,53 @@
+import WebSocket, { WebSocketServer } from 'ws'
+
+const upstreamUrl = 'wss://rpc.ibp.network/polkadot'
+const proxyPort = 9999
+
+const wss = new WebSocketServer({ port: proxyPort })
+
+let stall = false
+
+console.log(`Proxy running on ws://127.0.0.1:${proxyPort}`)
+
+wss.on('connection', (client) => {
+  const upstream = new WebSocket(upstreamUrl)
+
+  const messageQueue: string[] = []
+
+  upstream.on('open', () => {
+    console.log('Connected to upstream')
+
+    while (messageQueue.length > 0) {
+      const msg = messageQueue.shift()
+      if (msg) {
+        upstream.send(msg)
+      }
+    }
+  })
+
+  upstream.on('message', (msg) => {
+    if (!stall && client.readyState === WebSocket.OPEN) {
+      client.send(msg.toString())
+    }
+  })
+
+  client.on('message', (msg) => {
+    if (upstream.readyState === WebSocket.OPEN) {
+      upstream.send(msg.toString())
+    } else {
+      messageQueue.push(msg.toString())
+    }
+  })
+
+  client.on('close', () => upstream.close())
+})
+
+setTimeout(() => {
+  console.log('Stalling upstream messages...')
+  stall = true
+}, 10_000)
+
+setTimeout(() => {
+  console.log('Recovering upstream messages...')
+  stall = false
+}, 31_000)

--- a/packages/server/src/testing/tools/toxy.md
+++ b/packages/server/src/testing/tools/toxy.md
@@ -1,0 +1,13 @@
+run toxiproxy-server
+socat TCP-LISTEN:7000,reuseaddr,fork OPENSSL:rpc.ibp.network:443,verify=0
+toxiproxy-cli create substrate-ws --listen 127.0.0.1:9999 --upstream 127.0.0.1:7000
+toxiproxy-cli toggle substrate-ws # disconnect
+
+Freeze downstream
+toxiproxy-cli toxic add substrate-ws -t bandwidth -a rate=0 -d -n freeze
+
+Freeze both
+toxiproxy-cli toxic add substrate-ws -t bandwidth -a rate=0 -n freeze
+
+Restore
+toxiproxy-cli toxic remove substrate-ws -n freeze

--- a/packages/server/src/testing/tools/watcher.ts
+++ b/packages/server/src/testing/tools/watcher.ts
@@ -1,0 +1,59 @@
+import { pino } from 'pino'
+
+import { ServiceConfiguration } from '@/services/config.js'
+import Connector from '@/services/networking/connector.js'
+import { SubstrateWatcher } from '@/services/networking/substrate/watcher/watcher.js'
+import { Services } from '@/services/types.js'
+import { MemoryLevel } from 'memory-level'
+import { EMPTY, catchError } from 'rxjs'
+
+function createWatcher() {
+  const log = pino()
+  const localConfig = new ServiceConfiguration({
+    substrate: {
+      networks: [
+        {
+          id: 'urn:ocn:polkadot:0',
+          provider: {
+            type: 'rpc',
+            url: 'ws://127.0.0.1:9999/polkadot',
+          },
+        },
+      ],
+    },
+  })
+  const watcher = new SubstrateWatcher({
+    log,
+    connector: new Connector(log, localConfig),
+    levelDB: new MemoryLevel(),
+    localConfig,
+  } as unknown as Services)
+
+  watcher
+    .finalizedBlocks('urn:ocn:polkadot:0')
+    .pipe(
+      catchError((err) => {
+        console.error('Stream error:', err)
+        return EMPTY
+      }),
+    )
+    .subscribe({
+      next: (block) => console.log('B', block.number),
+      error: (err) => console.error('OBSERVABLE ERROR', err),
+      complete: () => console.log('OBSERVABLE COMPLETE! <<<'),
+    })
+
+  process.on('unhandledRejection', (reason, promise) => {
+    console.error('Unhandled Rejection at:', promise, 'reason:', reason)
+  })
+
+  process.on('uncaughtException', (error) => {
+    console.error('Uncaught Exception:', error)
+  })
+
+  process.on('beforeExit', (code) => {
+    console.log('>>> Node is about to exit with code', code)
+  })
+}
+
+createWatcher()


### PR DESCRIPTION
This case addresses a rare but real world scenario where an intermediate proxy stalls the web socket connection while keeping it open and responding to pings. We've observed this issue in production, occurring at least once a month with some rpc endpoints. To guard against it, we add a watchdog to the main streams with isolated reconnect logic for each client.